### PR TITLE
change difference_update to difference, added test case

### DIFF
--- a/pykismet3.py
+++ b/pykismet3.py
@@ -10,7 +10,7 @@ AKISMET_SUBMIT_HAM_URL = "rest.akismet.com/1.1/submit-ham"
 
 # API Permitted parameter lists
 AKISMET_CHECK_VALID_PARAMETERS = {
-        'blog', 
+        'blog',
         'user_ip',
         'user_agent',
         'referrer',
@@ -64,7 +64,7 @@ class Akismet:
         # Check if the API key is set
         if self.api_key is None:
             raise MissingApiKeyError("api_key must be set on the akismet object before calling any API methods.")
-        
+
         # Throw appropriate exception if any mandatory parameters are missing
         if not 'blog' in parameters:
             if self.blog_url is None:
@@ -76,10 +76,10 @@ class Akismet:
             raise MissingParameterError("user_agent is a required parameter")
         if not 'referrer' in parameters:
             raise MissingParameterError("referrer is a required parameter")
-        
+
         # Check for any invalid extra parameters
-        leftovers = set(parameters.keys()).difference_update(AKISMET_CHECK_VALID_PARAMETERS)
-        if leftovers and leftovers.count() != 0:
+        leftovers = set(parameters.keys()).difference(AKISMET_CHECK_VALID_PARAMETERS)
+        if leftovers and len(leftovers) != 0:
             raise ExtraParametersError("The following unrecognised parameters were supplied:"+str(leftovers))
 
         # Build the HTTP Headers for the Akismet query
@@ -150,4 +150,3 @@ class Akismet:
             return
         else:
             raise AkismetServerError("Akismet server returned an error: "+r.text)
-

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,34 @@
+import unittest
+
+from pykismet3 import Akismet, ExtraParametersError
+
+
+'''
+PykismetTestCase
+
+- tests for pykismet3 package
+- requires python requests module in order to run (pip install requests)
+
+'''
+
+class PykismetTestCase(unittest.TestCase):
+
+    # create an instance of the Akismet class
+    def setUp(self):
+
+        self.akismet_client = Akismet(blog_url="http://your.blog/url",
+                                      user_agent="My Awesome Web App/0.0.1",
+                                      api_key="testkey")
+
+
+    # test that class raises an ExtraParametersError when extra params are passed
+    def test_extra_parameters(self):
+        params = {'blog': 'http://your.blog/url',
+                  'user_ip': '1.1.1.1',
+                  'user_agent': 'My Awesome Web App/0.0.1',
+                  'referrer': 'http://your.blog/url',
+                  'some_extra': 'extra'
+                  }
+
+        with self.assertRaises(ExtraParametersError):
+            self.akismet_client.check(params)


### PR DESCRIPTION
Changed `difference_update` to `difference` because `difference_update` has no return value and updates the `set` in place. Also changed `leftovers.count()` to `len(leftovers)` because you can't call `count()` on a `set`.

Added a unittest to verify the change works. Requires the `requests` module to be installed in order to run.
Run with
`python -m unittest tests`
